### PR TITLE
Update neo4j-admin-command.txt

### DIFF
--- a/CSV_V2/neo4j-admin-command.txt
+++ b/CSV_V2/neo4j-admin-command.txt
@@ -2,4 +2,4 @@
 
 1. Run: cd bin
 
-2: Run: neo4j-admin import --multiline-fields=true --database=neo4j --nodes=../import/chcd-v-2-nodes.csv --relationships=../import/chcd-v-2-rels.csv
+2: Run: neo4j-admin database import full --multiline-fields=true --delimiter=@ --nodes=import/chcd_v2.3_nodes.csv --relationships=import/chcd_v2.3_edges.csv


### PR DESCRIPTION
Update the outdated command for database import.

Tested against the latest version of neo4j (1.6.0) and Graph DBMS (5.20.0). The database was imported successfully.


